### PR TITLE
summer 21 tos and pp updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repo mirrors the latest versions of LVN's public policies, including our:
 
 It exists in order to provide a public revision history of these policies. 
 
-The acting and binding versions of these documents live on the lvn.org domain at the following locations:
+The acting and binding versions of these documents live on the cortico.ai domain at the following locations:
 
-- [Privacy Policy](https://lvn.org/privacy)
-- [Terms of Use](https://lvn.org/terms)
+- [Privacy Policy](https://cortico.ai/privacy)
+- [Terms of Use](https://cortico.ai/terms)

--- a/privacy_policy.md
+++ b/privacy_policy.md
@@ -1,7 +1,7 @@
 CORTICO CORPORATION PRIVACY POLICY
 =================================
 
-*Effective date: August 11, 2021*  
+*Effective date: August 12, 2021*  
 
 At Cortico and the Local Voices Network (operated by Cortico), we take your privacy seriously. Please read this Privacy Policy to learn how we treat your personal information. **By using or accessing our Services in any manner, you acknowledge that you accept the practices and policies outlined below, and you hereby consent that we will collect, use and share your information as described in this Privacy Policy**.  
 

--- a/privacy_policy.md
+++ b/privacy_policy.md
@@ -1,7 +1,7 @@
 CORTICO CORPORATION PRIVACY POLICY
 =================================
 
-*Effective date: August 16, 2021*  
+*Effective date: August 11, 2021*  
 
 At Cortico and the Local Voices Network (operated by Cortico), we take your privacy seriously. Please read this Privacy Policy to learn how we treat your personal information. **By using or accessing our Services in any manner, you acknowledge that you accept the practices and policies outlined below, and you hereby consent that we will collect, use and share your information as described in this Privacy Policy**.  
 

--- a/privacy_policy.md
+++ b/privacy_policy.md
@@ -1,9 +1,9 @@
 CORTICO CORPORATION PRIVACY POLICY
 =================================
 
-*Effective date: June 26, 2020*  
+*Effective date: August 16, 2021*  
 
-At Cortico, we take your privacy seriously. Please read this Privacy Policy to learn how we treat your personal information. **By using or accessing our Services in any manner, you acknowledge that you accept the practices and policies outlined below, and you hereby consent that we will collect, use and share your information as described in this Privacy Policy**.  
+At Cortico and the Local Voices Network (operated by Cortico), we take your privacy seriously. Please read this Privacy Policy to learn how we treat your personal information. **By using or accessing our Services in any manner, you acknowledge that you accept the practices and policies outlined below, and you hereby consent that we will collect, use and share your information as described in this Privacy Policy**.  
 
 Remember that your use of Cortico’s Services is at all times subject to our [Terms of Use](https://lvn.org/terms), which incorporates this Privacy Policy. Any terms we use in this Policy without defining them have the definitions given to them in the Terms of Use.  
 
@@ -39,6 +39,7 @@ We collect Personal Data about you from the following categories of sources:
 * “Third Parties”
   * Third parties that provide us with Personal Data about you. Third Parties that share your Personal Data with us include:  
     * **Service providers**. For example, we may use analytics service providers to analyze how you interact and engage with the Services, or third parties may help us provide you with customer support.
+    * **Community Partners**. For example, we partner with third party community organizations to offer programming events.
 
 ### Information Collected Automatically
 
@@ -152,9 +153,13 @@ You have the right to request certain information about our collection and use o
 
 ### Deletion 
 
-You have the right to request that we delete the Personal Data that we have collected about you. Under the CCPA, this right is subject to certain exceptions: for example, we may need to retain your Personal Data to provide you with the Services or complete a transaction or other action you have requested. If your deletion request is subject to one of these exceptions, we may deny your deletion request.  
+You have the right to request that we delete the Personal Data that we have collected about you. To submit a request related to access, modification or deletion of your information, you can contact us through one of the points of contact at the bottom of this Privacy Policy or, if you are logged into your Cortico account, you can manage your privacy settings and other account features [here](https://app.lvn.org/settings). Please note that it may take a bit of time for privacy settings to be fully reflected throughout our systems. Under the CCPA, this right to deletion is subject to certain exceptions: for example, we may need to retain your Personal Data to provide you with the Services or complete a transaction or other action you have requested. If your deletion request is subject to one of these exceptions, we may deny your deletion request.  
 
 ### Exercising Your Rights 
+
+- Right to Access: If you are a California resident, you have the right to request (up to twice per year), access to categories and specific pieces of personal information about you that we collect, use, disclose, and sell.
+- Right to Delete: If you are a California resident, you have the right to request that we delete personal information that we collect from you, subject to applicable legal exceptions as mentioned above.
+- Right to Opt Out of Sale of Personal Information: If you are a California resident, you have the right to opt out of the sale of your personal information to third parties.
 
 To exercise the rights described above, you must send us a request that (1) provides sufficient information to allow us to verify that you are the person about whom we have collected Personal Data, including your email address used for lvn.org and the date and location of the conversation you participated in (if applicable) and (2) describes your request in sufficient detail to allow us to understand, evaluate and respond to it. Each request that meets both of these criteria will be considered a “Valid Request.” We may not respond to requests that do not meet these criteria. We will only use Personal Data provided in a Valid Request to verify your identity and complete your request. You do not need an account to submit a Valid Request. 
 

--- a/privacy_policy.md
+++ b/privacy_policy.md
@@ -5,9 +5,9 @@ CORTICO CORPORATION PRIVACY POLICY
 
 At Cortico and the Local Voices Network (operated by Cortico), we take your privacy seriously. Please read this Privacy Policy to learn how we treat your personal information. **By using or accessing our Services in any manner, you acknowledge that you accept the practices and policies outlined below, and you hereby consent that we will collect, use and share your information as described in this Privacy Policy**.  
 
-Remember that your use of Cortico’s Services is at all times subject to our [Terms of Use](https://lvn.org/terms), which incorporates this Privacy Policy. Any terms we use in this Policy without defining them have the definitions given to them in the Terms of Use.  
+Remember that your use of Cortico’s Services is at all times subject to our [Terms of Use](https://cortico.ai/terms), which incorporates this Privacy Policy. Any terms we use in this Policy without defining them have the definitions given to them in the Terms of Use.  
 
-You may print a copy of this Privacy Policy by clicking [here](javascript:window.print()). If you have a disability, you may access this Privacy Policy in an alternative format by contacting <help@lvn.org>. 
+You may print a copy of this Privacy Policy by clicking [here](javascript:window.print()). If you have a disability, you may access this Privacy Policy in an alternative format by contacting <help@cortico.ai>. 
 
 What this Privacy Policy Covers
 ------------------------------
@@ -73,7 +73,7 @@ We process Personal Data to operate, improve, understand and personalize our Ser
 
 We will not collect additional categories of Personal Data or use the Personal Data we collected for materially different, unrelated, or incompatible purposes without providing you notice. 
 
-As noted in the list above, we may communicate with you if you’ve provided us the means to do so. For example, if you’ve given us your email address, we may send you promotional email offers or email you about your use of the Services. Also, we may receive a confirmation when you open an email from us, which helps us improve our Services. If you do not want to receive communications from us, please indicate your preference by emailing us at <help@lvn.org>.  
+As noted in the list above, we may communicate with you if you’ve provided us the means to do so. For example, if you’ve given us your email address, we may send you promotional email offers or email you about your use of the Services. Also, we may receive a confirmation when you open an email from us, which helps us improve our Services. If you do not want to receive communications from us, please indicate your preference by emailing us at <help@cortico.ai>.  
 
 How We Share Your Personal Data 
 -------------------------------
@@ -111,9 +111,9 @@ We retain Personal Data about you for as long as you have an open account with u
 Personal Data of Children
 -------------------------
 
-As noted in the Terms of Use, we do not knowingly collect or solicit Personal Data about children under 13 years of age; if you are a child under the age of 13, please do not attempt to register for or otherwise use the Services or send us any Personal Data. If we learn we have collected Personal Data from a child under 13 years of age, we will delete that information as quickly as possible. If you believe that a child under 13 years of age may have provided Personal Data to us, please contact us at <help@lvn.org>.  
+As noted in the Terms of Use, we do not knowingly collect or solicit Personal Data about children under 13 years of age; if you are a child under the age of 13, please do not attempt to register for or otherwise use the Services or send us any Personal Data. If we learn we have collected Personal Data from a child under 13 years of age, we will delete that information as quickly as possible. If you believe that a child under 13 years of age may have provided Personal Data to us, please contact us at <help@cortico.ai>.  
 
-We may collect Personal Data from children under 18; if that data is shared by their parent or legal guardian and in accordance with the Children’s Online Privacy Protection Act (“COPPA”). We do not knowingly collect or solicit personally identifiable information from children under 18 without obtaining verifiable consent from that child’s parent or guardian, except for the limited amount of personally identifiable information we need to collect in order to obtain parental consent (“Required Information”). Until we have received parental consent, we will only use Required Information for the purpose of obtaining parental consent. If we learn we have collected Personal Data from a child under 18, without parental or legal guardian consent, we will delete that information as quickly as possible. If you are a parent or legal guardian of a child that has used LVN, or if you believe that a child under 18 may have provided us Personal Data, please contact us at <help@lvn.org>. 
+We may collect Personal Data from children under 18; if that data is shared by their parent or legal guardian and in accordance with the Children’s Online Privacy Protection Act (“COPPA”). We do not knowingly collect or solicit personally identifiable information from children under 18 without obtaining verifiable consent from that child’s parent or guardian, except for the limited amount of personally identifiable information we need to collect in order to obtain parental consent (“Required Information”). Until we have received parental consent, we will only use Required Information for the purpose of obtaining parental consent. If we learn we have collected Personal Data from a child under 18, without parental or legal guardian consent, we will delete that information as quickly as possible. If you are a parent or legal guardian of a child that has used LVN, or if you believe that a child under 18 may have provided us Personal Data, please contact us at <help@cortico.ai>. 
 
 User Protection 
 ---------------
@@ -138,7 +138,7 @@ California Resident Rights
 
 If you are a California resident, you have the rights set forth in this section. Please see the “Exercising Your Rights” section below for instructions regarding how to exercise these rights. Please note that we may process Personal Data of our customers’ end users or employees in connection with our provision of certain services to our customers. If we are processing your Personal Data as a service provider, you should contact the entity that collected your Personal Data in the first instance to address your rights with respect to such data. 
 
-If there are any conflicts between this section and any other provision of this Privacy Policy and you are a California resident, the portion that is more protective of Personal Data shall control to the extent of such conflict. If you have any questions about this section or whether any of the following rights apply to you, please contact us at <help@lvn.org>. 
+If there are any conflicts between this section and any other provision of this Privacy Policy and you are a California resident, the portion that is more protective of Personal Data shall control to the extent of such conflict. If you have any questions about this section or whether any of the following rights apply to you, please contact us at <help@cortico.ai>. 
 
 ### Access 
 
@@ -168,7 +168,7 @@ We will work to respond to your Valid Request within 45 days of receipt. We will
 You may submit a Valid Request using the following methods: 
 
 - Call us at: 617-404-9812 
-- Email us at: <help@lvn.org> 
+- Email us at: <help@cortico.ai> 
 
 You may also authorize an agent (an “Authorized Agent”) to exercise your rights on your behalf. To do this, you must provide your Authorized Agent with written permission to exercise your rights on your behalf, and we may request a copy of this written permission from your Authorized Agent when they make a request on your behalf. 
 
@@ -181,8 +181,8 @@ Other State Law Privacy Rights
 
 ### California Resident Rights 
 
-Under California Civil Code Sections 1798.83-1798.84, California residents are entitled to contact us to prevent disclosure of Personal Data to third parties for such third parties’ direct marketing purposes; in order to submit such a request, please contact us at <help@lvn.org>. 
+Under California Civil Code Sections 1798.83-1798.84, California residents are entitled to contact us to prevent disclosure of Personal Data to third parties for such third parties’ direct marketing purposes; in order to submit such a request, please contact us at <help@cortico.ai>. 
 
 ### Nevada Resident Rights 
 
-If you are a resident of Nevada, you have the right to opt-out of the sale of certain Personal Data to third parties who intend to license or sell that Personal Data. You can exercise this right by contacting us at <help@lvn.org> with the subject line “Nevada Do Not Sell Request” and providing us with your name and the email address associated with your account. Please note that we do not currently sell your Personal Data as sales are defined in Nevada Revised Statutes Chapter 603A.  
+If you are a resident of Nevada, you have the right to opt-out of the sale of certain Personal Data to third parties who intend to license or sell that Personal Data. You can exercise this right by contacting us at <help@cortico.ai> with the subject line “Nevada Do Not Sell Request” and providing us with your name and the email address associated with your account. Please note that we do not currently sell your Personal Data as sales are defined in Nevada Revised Statutes Chapter 603A.  

--- a/terms_of_use.md
+++ b/terms_of_use.md
@@ -5,11 +5,11 @@ Cortico Corporation - Terms of Use
 
 Welcome to Cortico, the operator of the Local Voices Network. Please read on to learn the rules and restrictions that govern your use of our website(s), products, services and applications (the “Services”). If you have any questions, comments, or concerns regarding these terms or the Services, please contact us at: 
 
-Email: <help@lvn.org>  
+Email: <help@cortico.ai>  
 Phone: 617-404-9812   
 Address: 177 Huntington Ave Ste 1703 #83158 Boston, MA 02115
 
-These Terms of Use (the “Terms”) are a binding contract between you and **CORTICO CORPORATION** (“Cortico,” “we” and “us”). Your use of the Services in any way means that you agree to all of these Terms, and these Terms will remain in effect while you use the Services. If you are using the Services on behalf of a company, you represent and warrant to us that you are authorized to bind the company, and these Terms shall also apply to the company (and, in such instance, “you” shall refer to both you and such company). These Terms include the provisions in this document as well as those in the [Privacy Policy](https://lvn.org/privacy), Copyright Dispute Policy and any other relevant policies. **Your use of or participation in certain Services may also be subject to additional policies, rules and/or conditions (“Additional Terms”), which are incorporated herein by reference, and you understand and agree that by using or participating in any such Services, you agree to also comply with these Additional Terms**.
+These Terms of Use (the “Terms”) are a binding contract between you and **CORTICO CORPORATION** (“Cortico,” “we” and “us”). Your use of the Services in any way means that you agree to all of these Terms, and these Terms will remain in effect while you use the Services. If you are using the Services on behalf of a company, you represent and warrant to us that you are authorized to bind the company, and these Terms shall also apply to the company (and, in such instance, “you” shall refer to both you and such company). These Terms include the provisions in this document as well as those in the [Privacy Policy](https://cortico.ai/privacy), Copyright Dispute Policy and any other relevant policies. **Your use of or participation in certain Services may also be subject to additional policies, rules and/or conditions (“Additional Terms”), which are incorporated herein by reference, and you understand and agree that by using or participating in any such Services, you agree to also comply with these Additional Terms**.
 
 **Please read these Terms carefully**. They cover important information about Services provided to you. **These Terms include information about [future changes to these Terms](#will-these-terms-ever-change), [limitations of liability](#limitation-of-liability), [a class action waiver and resolution of disputes by arbitration instead of in court](#arbitration-agreement). PLEASE NOTE THAT YOUR USE OF AND ACCESS TO OUR SERVICES ARE SUBJECT TO THE FOLLOWING TERMS; IF YOU DO NOT AGREE TO ALL OF THE FOLLOWING, YOU MAY NOT USE OR ACCESS THE SERVICES IN ANY MANNER**.
 
@@ -27,11 +27,15 @@ Except for changes by us as described here, no other amendment or modification o
 What about my privacy?
 ---------------------
 
+<<<<<<< HEAD
 Cortico takes the privacy of its users very seriously. By using the Services, you consent to our collection and use of personal data as outlined therein. For the current Cortico Privacy Policy, please click [here](https://lvn.org/privacy). 
+=======
+Cortico takes the privacy of its users very seriously. For the current Cortico Privacy Policy, please click [here](https://cortico.ai/privacy). 
+>>>>>>> f7e1b24... swap out lvn.org with cortico.ai
 
 ### Children’s Online Privacy Protection Act
 
-The Children’s Online Privacy Protection Act (“COPPA”) requires that online service providers obtain parental consent before they knowingly collect personally identifiable information online from children who are under thirteen (13). We do not knowingly collect or solicit personally identifiable information from children under thirteen (13); if you are a child under thirteen (13), please do not attempt to register for or otherwise use the Services or send us any personal information. If we learn we have collected personal information from a child under thirteen (13), we will delete that information as quickly as possible. If you believe that a child under thirteen (13) may have provided us personal information, please contact us at <help@lvn.org>.
+The Children’s Online Privacy Protection Act (“COPPA”) requires that online service providers obtain parental consent before they knowingly collect personally identifiable information online from children who are under thirteen (13). We do not knowingly collect or solicit personally identifiable information from children under thirteen (13); if you are a child under thirteen (13), please do not attempt to register for or otherwise use the Services or send us any personal information. If we learn we have collected personal information from a child under thirteen (13), we will delete that information as quickly as possible. If you believe that a child under thirteen (13) may have provided us personal information, please contact us at <help@cortico.ai>.
 
 ### EU Residents
 
@@ -104,7 +108,7 @@ A large portion of the content uploaded through the Cortico platform is produced
 
 ### Licenses 
 
-In order to display your User Submissions on the Services, and to allow other users to enjoy them (where applicable), you grant us certain rights in those User Submissions (see below for more information). Please note that all of the following licenses are subject to our [Privacy Policy](https://lvn.org/privacy) to the extent they relate to User Submissions that are also your personally-identifiable information. 
+In order to display your User Submissions on the Services, and to allow other users to enjoy them (where applicable), you grant us certain rights in those User Submissions (see below for more information). Please note that all of the following licenses are subject to our [Privacy Policy](https://cortico.ai/privacy) to the extent they relate to User Submissions that are also your personally-identifiable information. 
 
 By submitting User Submissions through the Services, you hereby do and shall grant Cortico a worldwide, non-exclusive, perpetual, royalty-free, fully paid, sublicensable and transferable license to use, edit, modify, truncate, aggregate, reproduce, distribute, prepare derivative works of, display, perform, and otherwise fully exploit the User Submissions in connection with this site, the Services and our (and our successors’ and assigns’) businesses, including without limitation for promoting and redistributing part or all of this site or the Services (and derivative works thereof) in any media formats and through any media channels (including, without limitation, third party websites and feeds), and including after your termination of your account or the Services. You also hereby do and shall grant each user of this site and/or the Services a non-exclusive, perpetual license to access your User Submissions through this site and/or the Services, and to use, edit, modify, reproduce, distribute, prepare derivative works of, display and perform such User Submissions, including after your termination of your account or the Services. For clarity, the foregoing license grants to us and our users do not affect your other ownership or license rights in your User Submissions, including the right to grant additional licenses to your User Submissions, unless otherwise agreed in writing. You represent and warrant that you have all rights to grant such licenses to us without infringement or violation of any third party rights, including without limitation, any privacy rights, publicity rights, copyrights, trademarks, contract rights, or any other intellectual property or proprietary rights. 
 
@@ -191,13 +195,13 @@ The Services are currently free, but we reserve the right to charge for certain 
 What if I want to stop using the Services? 
 ----------------------------------------
 
-You’re free to do that at any time by contacting us at <help@lvn.org>; please refer to our [Privacy Policy](https://lvn.org/privacy), as well as the licenses above, to understand how we treat information you provide to us after you have stopped using our Services.  
+You’re free to do that at any time by contacting us at <help@cortico.ai>; please refer to our [Privacy Policy](https://cortico.ai/privacy), as well as the licenses above, to understand how we treat information you provide to us after you have stopped using our Services.  
 
 Cortico is also free to terminate (or suspend access to) your use of the Services or your account for any reason in our discretion, including your breach of these Terms. Cortico has the sole right to decide whether you are in violation of any of the restrictions set forth in these Terms. 
 
 Account termination may result in destruction of any Content associated with your account, so keep that in mind before you decide to terminate your account. We will try to provide advance notice to you prior to our terminating your account so that you are able to retrieve any important User Submissions you may have stored in your account (to the extent allowed by law and these Terms), but we may not do so if we determine it would be impractical, illegal, not in the interest of someone’s safety or security, or otherwise harmful to the rights or property of Cortico. 
 
-If you have deleted your account by mistake, contact us immediately at <help@lvn.org> – we will try to help, but unfortunately, we can’t promise that we can recover or restore anything. 
+If you have deleted your account by mistake, contact us immediately at <help@cortico.ai> – we will try to help, but unfortunately, we can’t promise that we can recover or restore anything. 
 
 Provisions that, by their nature, should survive termination of these Terms shall survive termination. By way of example, all of the following will survive termination: any obligation you have to pay us or indemnify us, any limitations on our liability, any terms regarding ownership or intellectual property rights, and terms regarding disputes between us, including without limitation the arbitration agreement.  
 

--- a/terms_of_use.md
+++ b/terms_of_use.md
@@ -1,7 +1,7 @@
 Cortico Corporation - Terms of Use
 ==================================
 
-*Effective date: August 11, 2021*
+*Effective date: August 12, 2021*
 
 Welcome to Cortico, the operator of the Local Voices Network. Please read on to learn the rules and restrictions that govern your use of our website(s), products, services and applications (the “Services”). If you have any questions, comments, or concerns regarding these terms or the Services, please contact us at: 
 

--- a/terms_of_use.md
+++ b/terms_of_use.md
@@ -1,7 +1,7 @@
 Cortico Corporation - Terms of Use
 ==================================
 
-*Effective date: August 16, 2021*
+*Effective date: August 11, 2021*
 
 Welcome to Cortico, the operator of the Local Voices Network. Please read on to learn the rules and restrictions that govern your use of our website(s), products, services and applications (the “Services”). If you have any questions, comments, or concerns regarding these terms or the Services, please contact us at: 
 

--- a/terms_of_use.md
+++ b/terms_of_use.md
@@ -27,11 +27,7 @@ Except for changes by us as described here, no other amendment or modification o
 What about my privacy?
 ---------------------
 
-<<<<<<< HEAD
-Cortico takes the privacy of its users very seriously. By using the Services, you consent to our collection and use of personal data as outlined therein. For the current Cortico Privacy Policy, please click [here](https://lvn.org/privacy). 
-=======
-Cortico takes the privacy of its users very seriously. For the current Cortico Privacy Policy, please click [here](https://cortico.ai/privacy). 
->>>>>>> f7e1b24... swap out lvn.org with cortico.ai
+Cortico takes the privacy of its users very seriously. By using the Services, you consent to our collection and use of personal data as outlined therein. For the current Cortico Privacy Policy, please click [here](https://cortico.ai/privacy). 
 
 ### Children’s Online Privacy Protection Act
 

--- a/terms_of_use.md
+++ b/terms_of_use.md
@@ -1,9 +1,9 @@
 Cortico Corporation - Terms of Use
 ==================================
 
-*Effective date: June 26, 2020*
+*Effective date: August 16, 2021*
 
-Welcome to Cortico. Please read on to learn the rules and restrictions that govern your use of our website(s), products, services and applications (the “Services”). If you have any questions, comments, or concerns regarding these terms or the Services, please contact us at: 
+Welcome to Cortico, the operator of the Local Voices Network. Please read on to learn the rules and restrictions that govern your use of our website(s), products, services and applications (the “Services”). If you have any questions, comments, or concerns regarding these terms or the Services, please contact us at: 
 
 Email: <help@lvn.org>  
 Phone: 617-404-9812   
@@ -27,7 +27,7 @@ Except for changes by us as described here, no other amendment or modification o
 What about my privacy?
 ---------------------
 
-Cortico takes the privacy of its users very seriously. For the current Cortico Privacy Policy, please click [here](https://lvn.org/privacy). 
+Cortico takes the privacy of its users very seriously. By using the Services, you consent to our collection and use of personal data as outlined therein. For the current Cortico Privacy Policy, please click [here](https://lvn.org/privacy). 
 
 ### Children’s Online Privacy Protection Act
 
@@ -44,7 +44,7 @@ You may be required to sign up for an account, select a password and user name (
 
 You represent and warrant that you are an individual of legal age to form a binding contract (or if not, you’ve received your parent’s or guardian’s permission to use the Services and have gotten your parent or guardian to agree to these Terms on your behalf).  
 
-You will only use the Services for your internal, non-commercial use, and not on behalf of or for the benefit of any third party; provided, you may distribute content from the service through the use of service-provided content embed links, when available. If your use of the Services is prohibited by applicable laws, then you aren’t authorized to use the Services. We can’t and won’t be responsible for your using the Services in a way that breaks the law. 
+You will only use the Services for your internal, non-commercial use, and not on behalf of or for the benefit of any third party, unless otherwise expressly agreed to by Cortico; provided, you may distribute content from the service through the use of service-provided content embed links, when available. If your use of the Services is prohibited by applicable laws, then you aren’t authorized to use the Services. We can’t and won’t be responsible for your using the Services in a way that breaks the law. 
 
 You will not share your Cortico User ID, account or password with anyone, and you must protect the security of your Cortico User ID, account, password and any other access tools or credentials. You’re responsible for any activity associated with your Cortico User ID and account.  
 
@@ -94,9 +94,13 @@ What about anything I contribute to the Services – do I have to grant any lice
 
 Anything you post, upload, share, store, or otherwise provide through the Services is your “User Submission”. Some User Submissions may be viewable by other users. You are solely responsible for all User Submissions you contribute to the Services. You represent that all User Submissions submitted by you are accurate, complete, up-to-date, and in compliance with all applicable laws, rules and regulations.  
 
-You understand that your conversation will be recorded and transcribed. It may be made available to journalists, public officials, researchers, other participants and partners in the project, and eventually the general public, at Cortico’s discretion. By participating, you grant permission for your conversation to be recorded and transcribed. You further authorize Cortico and its sublicensees to use, publish, and sublicense your recorded voice from an LVN conversation, and to assert copyright in that recording and transcription. 
+You understand that your conversation will be recorded and transcribed. It may be made available to journalists, public officials, researchers, other participants and partners in the project, and eventually the general public, at Cortico’s discretion. By participating, you grant permission for your conversation to be recorded and transcribed. You further authorize Cortico and its sublicensees to use, publish, and sublicense your recorded voice from an LVN conversation, and for the party submitting the recording to assert copyright in that recording and transcription. 
 
-You agree that you will not post, upload, share, store, or otherwise provide through the Services any User Submissions that: (i) infringe any third party's copyrights or other rights (e.g., trademark, privacy rights, etc.); (ii) contain sexually explicit content or pornography; (iii) contain hateful, defamatory, or discriminatory content or incite hatred against any individual or group; (iv) exploit minors; (v) depict unlawful acts or extreme violence; (vi) depict animal cruelty or extreme violence towards animals; (vii) promote fraudulent schemes, multi-level marketing (MLM) schemes, get rich quick schemes, online gaming and gambling, cash gifting, work from home businesses, or any other dubious money-making ventures; or (viii) that violate any law. 
+You agree that you will not post, upload, share, store, or otherwise provide through the Services any User Submissions that: (i) infringe any third party's copyrights or other rights (e.g., trademark, privacy rights, etc.); (ii) contain sexually explicit content or pornography; (iii) contain hateful, defamatory, or discriminatory content or incite hatred against any individual or group; (iv) exploit minors; (v) depict unlawful acts or extreme violence; (vi) depict animal cruelty or extreme violence towards animals; (vii) promote fraudulent schemes, multi-level marketing (MLM) schemes, get rich quick schemes, online gaming and gambling, cash gifting, work from home businesses, or any other dubious money-making ventures; or (viii) that violate any law.
+
+### Content Involving Others
+
+A large portion of the content uploaded through the Cortico platform is produced by our users, partners, and other third parties. The content is the sole responsibility of the party that submitted it. Cortico reserves the right to review or remove all content that appears on the Services, but we do not necessarily review all of it. So we cannot—and do not—take responsibility for any content that others provide through the Services.
 
 ### Licenses 
 


### PR DESCRIPTION
At a high level, these changes are intended to provide Cortico with greater flexibility in how we work with our partners, while freshening up some of our legal language. They include:

- Adding mention of the Local Voices Network as a program operated by Cortico
- Adding _community partners_ as a source of third-party data (e.g. when a user provides an email address of a team member or a conversation participant in order to invite them to access the platform)
- Adding additional information about data rights for California residents under CCPA
- Adding a carve out for usage of the platform outside of our standard terms if agreed to between Cortico and a partner. These are typically written into a Professional Services Agreement.
- Adding language about content uploaded to the platform by partners: that the partner may hold the copyright, and that Cortico reserves the right to review and remove content uploaded by third parties.